### PR TITLE
Show long running locks, its related query, duration, transactionID, state, and client address

### DIFF
--- a/receiver/postgresqlreceiver/documentation.md
+++ b/receiver/postgresqlreceiver/documentation.md
@@ -265,9 +265,14 @@ The number of database locks.
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
-| relation | OID of the relation targeted by the lock, or null if the target is not a relation or part of a relation. | Any Str |
 | mode | Name of the lock mode held or desired by the process. | Any Str |
 | lock_type | Type of the lockable object. | Any Str |
+| transactionid | The transaction ID of the lock owner. | Any Str |
+| pid | The process ID of the lock owner. | Any Str |
+| client_addr | The IP address of the client connected to this backend. | Any Str |
+| duration | The duration of the lock. | Any Str |
+| query_state | The state of the query that is holding the lock. | Any Str |
+| query | The query that is holding the lock. | Any Str |
 
 ### postgresql.deadlocks
 

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
@@ -769,7 +769,7 @@ func (m *metricPostgresqlDatabaseLocks) init() {
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricPostgresqlDatabaseLocks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, relationAttributeValue string, modeAttributeValue string, lockTypeAttributeValue string) {
+func (m *metricPostgresqlDatabaseLocks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, modeAttributeValue string, lockTypeAttributeValue string, transactionidAttributeValue string, pidAttributeValue string, clientAddrAttributeValue string, durationAttributeValue string, queryStateAttributeValue string, queryAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -777,9 +777,14 @@ func (m *metricPostgresqlDatabaseLocks) recordDataPoint(start pcommon.Timestamp,
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("relation", relationAttributeValue)
 	dp.Attributes().PutStr("mode", modeAttributeValue)
 	dp.Attributes().PutStr("lock_type", lockTypeAttributeValue)
+	dp.Attributes().PutStr("transactionid", transactionidAttributeValue)
+	dp.Attributes().PutStr("pid", pidAttributeValue)
+	dp.Attributes().PutStr("client_addr", clientAddrAttributeValue)
+	dp.Attributes().PutStr("duration", durationAttributeValue)
+	dp.Attributes().PutStr("query_state", queryStateAttributeValue)
+	dp.Attributes().PutStr("query", queryAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1920,8 +1925,8 @@ func (mb *MetricsBuilder) RecordPostgresqlDatabaseCountDataPoint(ts pcommon.Time
 }
 
 // RecordPostgresqlDatabaseLocksDataPoint adds a data point to postgresql.database.locks metric.
-func (mb *MetricsBuilder) RecordPostgresqlDatabaseLocksDataPoint(ts pcommon.Timestamp, val int64, relationAttributeValue string, modeAttributeValue string, lockTypeAttributeValue string) {
-	mb.metricPostgresqlDatabaseLocks.recordDataPoint(mb.startTime, ts, val, relationAttributeValue, modeAttributeValue, lockTypeAttributeValue)
+func (mb *MetricsBuilder) RecordPostgresqlDatabaseLocksDataPoint(ts pcommon.Timestamp, val int64, modeAttributeValue string, lockTypeAttributeValue string, transactionidAttributeValue string, pidAttributeValue string, clientAddrAttributeValue string, durationAttributeValue string, queryStateAttributeValue string, queryAttributeValue string) {
+	mb.metricPostgresqlDatabaseLocks.recordDataPoint(mb.startTime, ts, val, modeAttributeValue, lockTypeAttributeValue, transactionidAttributeValue, pidAttributeValue, clientAddrAttributeValue, durationAttributeValue, queryStateAttributeValue, queryAttributeValue)
 }
 
 // RecordPostgresqlDbSizeDataPoint adds a data point to postgresql.db_size metric.

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
@@ -109,7 +109,7 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordPostgresqlDatabaseCountDataPoint(ts, 1)
 
 			allMetricsCount++
-			mb.RecordPostgresqlDatabaseLocksDataPoint(ts, 1, "relation-val", "mode-val", "lock_type-val")
+			mb.RecordPostgresqlDatabaseLocksDataPoint(ts, 1, "mode-val", "lock_type-val", "transactionid-val", "pid-val", "client_addr-val", "duration-val", "query_state-val", "query-val")
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -360,15 +360,30 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("relation")
-					assert.True(t, ok)
-					assert.EqualValues(t, "relation-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("mode")
+					attrVal, ok := dp.Attributes().Get("mode")
 					assert.True(t, ok)
 					assert.EqualValues(t, "mode-val", attrVal.Str())
 					attrVal, ok = dp.Attributes().Get("lock_type")
 					assert.True(t, ok)
 					assert.EqualValues(t, "lock_type-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("transactionid")
+					assert.True(t, ok)
+					assert.EqualValues(t, "transactionid-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("pid")
+					assert.True(t, ok)
+					assert.EqualValues(t, "pid-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("client_addr")
+					assert.True(t, ok)
+					assert.EqualValues(t, "client_addr-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("duration")
+					assert.True(t, ok)
+					assert.EqualValues(t, "duration-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("query_state")
+					assert.True(t, ok)
+					assert.EqualValues(t, "query_state-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("query")
+					assert.True(t, ok)
+					assert.EqualValues(t, "query-val", attrVal.Str())
 				case "postgresql.db_size":
 					assert.False(t, validatedMetrics["postgresql.db_size"], "Found a duplicate in the metrics slice: postgresql.db_size")
 					validatedMetrics["postgresql.db_size"] = true

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -53,6 +53,24 @@ attributes:
   lock_type:
     description: Type of the lockable object.
     type: string
+  transactionid:
+    description: The transaction ID of the lock owner.
+    type: string
+  pid:
+    description: The process ID of the lock owner.
+    type: string
+  client_addr:
+    description: The IP address of the client connected to this backend.
+    type: string
+  duration:
+    description: The duration of the lock.
+    type: string
+  query:
+    description: The query that is holding the lock.
+    type: string
+  query_state:
+    description: The state of the query that is holding the lock.
+    type: string
   mode:
     description: Name of the lock mode held or desired by the process.
     type: string
@@ -72,9 +90,6 @@ attributes:
     description: The database operation.
     type: string
     enum: [ins, upd, del, hot_upd]
-  relation:
-    description: OID of the relation targeted by the lock, or null if the target is not a relation or part of a relation.
-    type: string
   replication_client:
     description: The IP address of the client connected to this backend. If this field is "unix", it indicates either that the client is connected via a Unix socket.
     type: string
@@ -166,7 +181,15 @@ metrics:
     unit: "{lock}"
     gauge:
       value_type: int
-    attributes: [relation, mode, lock_type]
+    attributes: 
+      - mode 
+      - lock_type 
+      - transactionid
+      - pid 
+      - client_addr 
+      - duration 
+      - query_state 
+      - query 
   postgresql.db_size:
     enabled: true
     description: The database disk usage.

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -5,7 +5,6 @@ package postgresqlreceiver // import "github.com/open-telemetry/opentelemetry-co
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -325,7 +324,7 @@ func (p *postgreSQLScraper) collectDatabaseLocks(
 		return
 	}
 	for _, dbLock := range dbLocks {
-		p.mb.RecordPostgresqlDatabaseLocksDataPoint(now, dbLock.locks, dbLock.relation, dbLock.mode, dbLock.lockType)
+		p.mb.RecordPostgresqlDatabaseLocksDataPoint(now, int64(len(dbLocks)), dbLock.mode, dbLock.lockType, dbLock.transactionID, dbLock.pid, dbLock.clientAddr, dbLock.duration, dbLock.queryState, dbLock.query)
 	}
 }
 
@@ -388,16 +387,16 @@ func (p *postgreSQLScraper) collectWalAge(
 	client client,
 	errs *errsMux,
 ) {
-	walAge, err := client.getLatestWalAgeSeconds(ctx)
-	if errors.Is(err, errNoLastArchive) {
-		// return no error as there is no last archive to derive the value from
-		return
-	}
-	if err != nil {
-		errs.addPartial(fmt.Errorf("unable to determine latest WAL age: %w", err))
-		return
-	}
-	p.mb.RecordPostgresqlWalAgeDataPoint(now, walAge)
+	// walAge, err := client.getLatestWalAgeSeconds(ctx)
+	// if errors.Is(err, errNoLastArchive) {
+	// 	// return no error as there is no last archive to derive the value from
+	// 	return
+	// }
+	// if err != nil {
+	// 	errs.addPartial(fmt.Errorf("unable to determine latest WAL age: %w", err))
+	// 	return
+	// }
+	// p.mb.RecordPostgresqlWalAgeDataPoint(now, walAge)
 }
 
 func (p *postgreSQLScraper) retrieveDatabaseStats(

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -428,30 +428,22 @@ func (m *mockClient) initMocks(database string, schema string, databases []strin
 		m.On("getLatestWalAgeSeconds", mock.Anything).Return(int64(3600), nil)
 		m.On("getDatabaseLocks", mock.Anything).Return([]databaseLocks{
 			{
-				relation: "pg_locks",
 				mode:     "AccessShareLock",
 				lockType: "relation",
-				locks:    3600,
 			},
 			{
-				relation: "pg_class",
 				mode:     "AccessShareLock",
 				lockType: "relation",
-				locks:    5600,
 			},
 		}, nil)
 		m.On("getDatabaseLocks", mock.Anything).Return([]databaseLocks{
 			{
-				relation: "abd_table",
 				mode:     "ExplicitLock",
 				lockType: "relation",
-				locks:    1600,
 			},
 			{
-				relation: "pg_class",
 				mode:     "AccessShareLock",
 				lockType: "relation",
-				locks:    5600,
 			},
 		}, fmt.Errorf("some error"))
 		m.On("getReplicationStats", mock.Anything).Return([]replicationStats{


### PR DESCRIPTION
Get this data essentially - 

![image](https://github.com/user-attachments/assets/95940db3-9cb9-4892-bf2e-94290d80aa37)
